### PR TITLE
Fix Integrant resume-key method

### DIFF
--- a/src/sass4clj/integrant.clj
+++ b/src/sass4clj/integrant.clj
@@ -5,15 +5,15 @@
 (defmethod ig/init-key ::sass4clj [_ options]
   (api/start options))
 
-(defmethod ig/halt-key! ::sass4clj [this options]
-  (api/stop this))
+(defmethod ig/halt-key! ::sass4clj [_ watcher]
+  (api/stop watcher))
 
-(defmethod ig/suspend-key! ::sass4clj [this options]
+(defmethod ig/suspend-key! ::sass4clj [_ watcher]
   nil)
 
 (defmethod ig/resume-key ::sass4clj [key opts old-opts old-impl]
   (if (= opts old-opts)
     old-impl
     (do
-      (ig/halt-key! key old-opts)
+      (ig/halt-key! key old-impl)
       (ig/init-key key opts))))


### PR DESCRIPTION
When resuming an Integrant component, this now halts the old
implementation, rather than the old options.

I think this is the correct behaviour? When I tried to use this out of the box, I got an NPE when resuming after changing some config.