### PR TITLE
Fix support for include paths

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -6,7 +6,7 @@
   :dependencies   '[[org.clojure/clojure "1.10.1" :scope "provided"]
                     [metosin/bat-test "0.4.3" :scope "test"]
 
-                    [io.bit3/jsass "5.10.0"]
+                    [io.bit3/jsass "5.10.3"]
                     [cheshire "5.9.0"]
 
                     [org.webjars/webjars-locator "0.37"]
@@ -18,7 +18,7 @@
                     [integrant "0.7.0" :scope "test"]
 
                     ;; Webjars-locator uses logging
-                    [org.slf4j/slf4j-nop "1.7.25" :scope "test"]
+                    [org.slf4j/slf4j-nop "1.7.29" :scope "test"]
 
                     ;; For testing the webjars asset locator implementation
                     [org.webjars.bower/bootstrap "4.3.1" :scope "test"]

--- a/deps.edn
+++ b/deps.edn
@@ -2,5 +2,6 @@
         cheshire {:mvn/version "5.9.0"}
         org.webjars/webjars-locator {:mvn/version "0.37"}
         hawk {:mvn/version "0.2.11"}
-        org.clojure/tools.cli {:mvn/version "0.4.2"}
-        org.slf4j/slf4j-nop {:mvn/version "1.7.29"}}}
+        org.clojure/tools.cli {:mvn/version "0.4.2"}}
+
+ :aliases {:test {:extra-deps {org.slf4j/slf4j-nop {:mvn/version "1.7.29"}}}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
-{:deps {io.bit3/jsass {:mvn/version "5.5.2"}
-        cheshire {:mvn/version "5.7.1"}
-        org.webjars/webjars-locator {:mvn/version "0.32-1"}
+{:deps {io.bit3/jsass {:mvn/version "5.10.3"}
+        cheshire {:mvn/version "5.9.0"}
+        org.webjars/webjars-locator {:mvn/version "0.37"}
         hawk {:mvn/version "0.2.11"}
-        org.clojure/tools.cli {:mvn/version "0.4.1"}
-        org.slf4j/slf4j-nop {:mvn/version "1.7.25"}}}
+        org.clojure/tools.cli {:mvn/version "0.4.2"}
+        org.slf4j/slf4j-nop {:mvn/version "1.7.29"}}}

--- a/src/sass4clj/api.clj
+++ b/src/sass4clj/api.clj
@@ -39,7 +39,7 @@
               (core/sass-compile-to-file
                 path
                 (.getPath (io/file target-path (string/replace relative-path #"\.(scss|sass)$" ".css")))
-                (dissoc options :target-path :source-paths))
+                (dissoc options :target-path))
               (catch Exception e
                 (if auto
                   (println (.getMessage e))
@@ -65,13 +65,12 @@
 (defn build [{:keys [source-paths auto] :as options}]
   (when-not (s/valid? ::options options)
     (s/explain-out (s/explain-data ::options options)))
-  (let [options (dissoc options :source-paths)]
-    (if auto
-      (watcher/start source-paths (fn [& _]
-                                    (let [main-files (find-main-files source-paths options)]
-                                      (compile-sass main-files options))))
-      (let [main-files (find-main-files source-paths options)]
-        (compile-sass main-files options)))))
+  (if auto
+    (watcher/start source-paths (fn [& _]
+                                  (let [main-files (find-main-files source-paths options)]
+                                    (compile-sass main-files options))))
+    (let [main-files (find-main-files source-paths options)]
+      (compile-sass main-files options))))
 
 (defn start [options]
   (build (assoc options :auto true)))

--- a/test/sass4clj/api_test.clj
+++ b/test/sass4clj/api_test.clj
@@ -1,0 +1,37 @@
+(ns sass4clj.api-test
+  (:require [clojure.test :refer [deftest is]]
+            [clojure.java.io :as io]
+            [sass4clj.api :as sass])
+  (:import (java.nio.file Files)
+           (java.nio.file.attribute FileAttribute)))
+
+(defn- temp-dir
+  [prefix]
+  (.toString (Files/createTempDirectory prefix (into-array FileAttribute []))))
+
+(def ^:private includer-scss
+  "body {
+  color: red;
+}
+
+@import 'includee';
+")
+
+(def ^:private includee-sass
+  "@charset 'utf-8'
+
+p
+  color: blue
+")
+
+(deftest include-paths
+  (let [input-dir (temp-dir "sass4clj-input")
+        include-dir (temp-dir "sass4clj-include")
+        output-dir (temp-dir "sass4clj-output")
+        options {:source-paths [input-dir include-dir]
+                 :target-path  output-dir}]
+    (spit (io/file input-dir "includer.scss") includer-scss)
+    (spit (io/file include-dir "includee.sass") includee-sass)
+    (sass/build options)
+    (is (= "body {\n  color: red; }\n\np {\n  color: blue; }\n"
+           (slurp (io/file output-dir "includer.css"))))))


### PR DESCRIPTION
I wanted to install Bulma via NPM, add `node_modules` into `:source-paths` and include the Bulma SASS files in my project SCSS files, but that didn't work. Turns out that was because when calling via the `sass4clj.api` namespace, `:source-paths` were getting removed from the `options` map and not getting added into include paths.

I also made a couple of changes that make it easier to use sass4clj as a Git dependency. Two issues remain there: sass4clj has a kind of an implicit dependency to both Component and Integrant, but neither are included in `deps.edn`. They're marked as test dependencies in `build.boot`, which is a bit odd — should they be `:provided` instead?