### PR TITLE
Canonicalize lib names in deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:deps {io.bit3/jsass {:mvn/version "5.10.3"}
-        cheshire {:mvn/version "5.9.0"}
+        cheshire/cheshire {:mvn/version "5.9.0"}
         org.webjars/webjars-locator {:mvn/version "0.37"}
-        hawk {:mvn/version "0.2.11"}
+        hawk/hawk {:mvn/version "0.2.11"}
         org.clojure/tools.cli {:mvn/version "0.4.2"}}
 
  :aliases {:test {:extra-deps {org.slf4j/slf4j-nop {:mvn/version "1.7.29"}}}}}


### PR DESCRIPTION
Unqualified lib names are being deprecated in deps.edn and will warn